### PR TITLE
Add logo and docs enhancements

### DIFF
--- a/.codex/agents.md
+++ b/.codex/agents.md
@@ -1,0 +1,3 @@
+# Codex Agent Instructions
+
+Run `.codex/setup.sh` before executing validation or testing commands. No additional tools are required for this repository.

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# Install dependencies for validation
+# (placeholder - no dependencies required for this project)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![HHS Logo](images/logos/hhs-lg.png)
+
 ## hhs.github.io
 
 Landing page to direct visitors to HHS-related GitHub accounts, repositories and pages that are maintained under various names by HHS operating divisions, and staff offices. HHS, as an umbrella organization, has its own GitHub organizational account (github.com/hhs) that hosts repos, and this GitHub.io page. This site's code is publicly available.
@@ -22,3 +24,4 @@ More documentation on installing Jekyll and its dependencies at [Jekyll's instal
 ## about HHS 
 
 The United States Department of Health and Human Services (HHS) protects health and provides essential human services. HHS has 11 operating divisions, including 8 agencies in the US Public Health Service and 3 human services agencies that administer a wide variety of health and human services and conduct life-saving research for the nation. HHS has 17 staff offices that oversee operations and provide guidance on policy issues and program implementation. Learn more here: http://www.hhs.gov/about/
+For more details see [documentation](docs/README.md).

--- a/_data/README.md
+++ b/_data/README.md
@@ -1,0 +1,3 @@
+# Data Files
+
+YAML files in this folder provide account and repository information used by the site.

--- a/_includes/README.md
+++ b/_includes/README.md
@@ -1,0 +1,3 @@
+# Includes
+
+Reusable snippets such as CSS and JavaScript assets.

--- a/_includes/css/README.md
+++ b/_includes/css/README.md
@@ -1,0 +1,3 @@
+# CSS Assets
+
+Stylesheets used across the site.

--- a/_includes/js/README.md
+++ b/_includes/js/README.md
@@ -1,0 +1,3 @@
+# JavaScript Assets
+
+Scripts leveraged by the site for interactivity.

--- a/_layouts/README.md
+++ b/_layouts/README.md
@@ -1,0 +1,3 @@
+# Layout Templates
+
+HTML layouts for various pages of the site.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+This directory contains additional information about using and maintaining the site.
+
+See [branding guidelines](branding.md) for logo usage.
+
+Back to [project README](../README.md).

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,7 @@
+# Branding Guidelines
+
+Use the official HHS logo when referencing this project.
+
+![HHS Large Logo](../images/logos/hhs-lg.png)
+
+Place logos in the `images/logos` directory and reference them using relative paths as shown above.

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,3 @@
+# Images
+
+Graphics used within the website including icons and logos.

--- a/images/icons/README.md
+++ b/images/icons/README.md
@@ -1,0 +1,3 @@
+# Icons
+
+Various icon assets for site navigation and UI elements.

--- a/images/icons_gly/README.md
+++ b/images/icons_gly/README.md
@@ -1,0 +1,3 @@
+# Glyph Icons
+
+Glyph-based icons used throughout the site.

--- a/images/logos/README.md
+++ b/images/logos/README.md
@@ -1,0 +1,3 @@
+# Logos
+
+Official organization logos for use on the site.


### PR DESCRIPTION
## Summary
- show `hhs-lg.png` logo at the top of the README
- add link from README to new docs folder
- document logo usage in `docs/branding.md`
- add README files for project folders
- add `.codex` setup and agent instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c26860cbc8327974183e91dfd96de